### PR TITLE
README.md: Add instructions for running from Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 http://galeb.io Docker image
 
 
+Run from Docker Hub
+-------------------
+
+```
+docker run -it -p 9000:9000 wpjunior/galeb-docker
+```
+
 Build
 -----
 


### PR DESCRIPTION
Probably want to add this to the description on the Docker Hub too:

https://registry.hub.docker.com/u/wpjunior/galeb-docker/